### PR TITLE
Fix typo on in TS module name

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "adonisjs": {
     "types": "@cavai/adonis-queue",
     "providers": [
-      "@cavai/Adonis-Queue"
+      "@cavai/adonis-queue"
     ],
     "templates": {
       "start": [

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "license": "MIT",
   "adonisjs": {
-    "types": "@cavai/Adonis-Queue",
+    "types": "@cavai/adonis-queue",
     "providers": [
       "@cavai/Adonis-Queue"
     ],


### PR DESCRIPTION
## Proposed changes

Fixes typo in typings module name that get auto-added to `tsconfig.json` after `node ace invoke`
![image](https://user-images.githubusercontent.com/6796697/176324371-8ea5c0c6-a3aa-4f9c-ad33-b3763348f8a9.png)
Notice the red underline on left

After this fix it's no longer in there:
![image](https://user-images.githubusercontent.com/6796697/176324500-8359ea51-cb17-459a-8ab3-123497ea282b.png)


## Types of changes

Just a small typo fix

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Cavai/Adonis-Queue/blob/master/.github/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
