### PR TITLE
Add job delaying

### DIFF
--- a/adonis-typings/queue.ts
+++ b/adonis-typings/queue.ts
@@ -20,8 +20,12 @@ declare module '@ioc:Cavai/Adonis-Queue' {
     reportProgress(progress: any): void
   }
 
+  export interface AddOptions {
+    runAt?: number
+  }
+
   export interface DriverContract {
-    add<T extends Record<string, any>>(payload: T): Promise<JobContract<T>>
+    add<T extends Record<string, any>>(payload: T, options?: AddOptions): Promise<JobContract<T>>
     process(callback: (job: JobContract<any>) => Promise<void>): void
     getJob(id: number | string): Promise<JobContract<any> | null>
     close(): Promise<void>

--- a/adonis-typings/queue.ts
+++ b/adonis-typings/queue.ts
@@ -15,6 +15,8 @@ declare module '@ioc:Cavai/Adonis-Queue' {
 
   export interface JobContract<T extends Record<string, any>> {
     id: string | number
+    runAt: number
+    delayed: boolean
     payload: T
     progress?: any
     reportProgress(progress: any): void

--- a/tests/queue.spec.ts
+++ b/tests/queue.spec.ts
@@ -11,9 +11,16 @@ const configs = {
   ...redis,
 }
 
+const configsDelayed = Object.fromEntries(
+  Object.entries(configs).map(([k, v]) => [
+    k + 'Delayed',
+    { ...v, config: { ...v.config, activateDelayedJobs: true } },
+  ])
+)
+
 for (const [name, config] of Object.entries(configs))
   test.group(`${capitalize(config.driver)}Queue`, (group) => {
-    setupGroup(group, configs)
+    setupGroup(group, { ...configs, ...configsDelayed })
 
     test(`missing queue name throws exception`, async ({ queues, expect }) => {
       expect(queues.use).toThrow(Error)
@@ -114,6 +121,52 @@ for (const [name, config] of Object.entries(configs))
       const job = await queue2.getJob(id)
       expect(job).toBeTruthy
     })
+
+    test('scheduled job is never processed if delayed jobs are not active', async function ({
+      queues,
+      expect,
+    }) {
+      const queue = queues.use(name)
+      let done = false
+
+      queue.process(async () => {
+        done = true
+      })
+      await queue.add({}, { runAt: Date.now() + 300 })
+      await sleep(1000)
+      expect(done).toBe(false)
+    })
+
+    test('scheduled job is processed with a delay if delayed jobs are active', async function ({
+      queues,
+      expect,
+    }) {
+      const queue = queues.use(name + 'Delayed')
+      let done = false
+
+      queue.process(async () => {
+        done = true
+      })
+      await queue.add({}, { runAt: Date.now() + 300 })
+      await sleep(100)
+      expect(done).toBe(false)
+      await sleep(1000)
+      expect(done).toBe(true)
+    })
+
+    test('scheduled jobs are started in the right order', async function ({ queues, expect }) {
+      const queue = queues.use(name + 'Delayed')
+      const started: any = []
+
+      queue.process(async (job) => started.push(job.id))
+      const job1 = await queue.add({})
+      const job2 = await queue.add({}, { runAt: Date.now() + 1000 })
+      const job3 = await queue.add({})
+      const job4 = await queue.add({}, { runAt: Date.now() + 300 })
+
+      await sleep(1500)
+      expect(started).toEqual([job1.id, job3.id, job4.id, job2.id])
+    })
   })
 
 test.group(`ExtendedQueue`, (group) => {
@@ -135,43 +188,3 @@ test.group(`ExtendedQueue`, (group) => {
     expect(job).toBeTruthy()
   })
 })
-
-if (redisHost)
-  test.group('Job scheduling', (group) => {
-    setupGroup(group, {
-      red: { driver: 'redis', config: { host: redisHost } },
-      delay: { driver: 'redis', config: { host: redisHost, activateDelayedJobs: true } },
-    })
-
-    test('job is never processed if delayed jobs are not active', async function ({
-      queues,
-      expect,
-    }) {
-      const queue = queues.use('red')
-      let done = false
-
-      queue.process(async () => {
-        done = true
-      })
-      await queue.add({}, { runAt: Date.now() + 300 })
-      await sleep(1000)
-      expect(done).toBe(false)
-    })
-
-    test('job is processed with a delay if delayed jobs are active', async function ({
-      queues,
-      expect,
-    }) {
-      const queue = queues.use('delay')
-      let done = false
-
-      queue.process(async () => {
-        done = true
-      })
-      await queue.add({}, { runAt: Date.now() + 300 })
-      await sleep(100)
-      expect(done).toBe(false)
-      await sleep(1000)
-      expect(done).toBe(true)
-    })
-  })


### PR DESCRIPTION
## Proposed changes

This PR adds an option to delay jobs by enabling `activateDelayedJobs` setting in the queue and adding `runAt` timestamp to jobs which is the standard JS numeric timestamp.

Closes: #18 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/Cavai/Adonis-Queue/blob/master/.github/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)

## Further comments

It is possible to schedule jobs by adding the same job with a new `runAt` timestamp at the end of the previous one. This will not work with crashing or stalling jobs, though.
