### PR TITLE
Ensure Jobs and migrations paths exist

### DIFF
--- a/instructions.ts
+++ b/instructions.ts
@@ -9,8 +9,8 @@ export default async function instructions(
 ) {
   // Copy over ExampleJob.ts
   new sink.files.MustacheFile(
-    app.makePath('app/Jobs'),
-    'ExampleJob.ts',
+    app.makePath('app'),
+    'Jobs/ExampleJob.ts',
     join(__dirname, 'templates/ExampleJob.txt')
   )
     .apply({ name: 'TestJob', filename: 'TestJob', useMustache: true })
@@ -18,8 +18,8 @@ export default async function instructions(
 
   // Copy over Migration
   new sink.files.TemplateLiteralFile(
-    app.makePath('database/migrations'),
-    `${Date.now()}_queue_migration.ts`,
+    app.makePath('database'),
+    `migrations/${Date.now()}_queue_migration.ts`,
     join(__dirname, 'templates/queue_migration.txt')
   )
     .apply({})


### PR DESCRIPTION
This PR fixes https://github.com/cavai-research/Adonis-Queue/issues/30

Which made it impossible to call `node ace invoke @cavai/adonis-queue` in new projects. Since `Jobs` and `migrations` folders don't exist yet