### PR TITLE
Return job ID after dispatching / storing

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ queue up for execution
 import MailJob from 'App/Jobs/Mails/MailJob'
 
 // And then dispatch it with optional payload
-await MailJob.dispatch({ name: '123', id: 123, signup_date: new Date() })
+const job = await MailJob.dispatch({ name: '123', id: 123, signup_date: new Date() })
+console.log(job) // { id: 7902 }
 ```
 
 Awaiting dispatch does **not** wait for execution, it waits for job to be stored
@@ -134,6 +135,8 @@ to queue
 `.dispatch()` accepts payload that will be accessible in job class `handle()`
 method. They will be added to class instance, so in current example `name` will
 be accessible with `this.payload.name`
+
+Job dispatch returns object with job ID, which can be later used for job progress tracking
 
 ### Delaying job
 
@@ -298,4 +301,3 @@ export default defineConfig({
 
 - Add memory queue
 - Add more tests
-

--- a/src/Dispatcher.ts
+++ b/src/Dispatcher.ts
@@ -1,7 +1,7 @@
 import { DateTime } from 'luxon'
 import { BaseJob } from './BaseJob'
 
-type DispatcherResult = void
+type DispatcherResult = { id: number | string }
 
 export class Dispatcher<T extends typeof BaseJob> implements Promise<DispatcherResult> {
   public then<TResult1 = DispatcherResult, TResult2 = never>(
@@ -52,7 +52,7 @@ export class Dispatcher<T extends typeof BaseJob> implements Promise<DispatcherR
       version: 'v1',
     }
 
-    await this.job.queueManager.store(this.job.classPath, payload, {
+    return this.job.queueManager.store(this.job.classPath, payload, {
       availableAt: this.availableAt,
     })
   }

--- a/src/Drivers/Database.ts
+++ b/src/Drivers/Database.ts
@@ -14,11 +14,18 @@ export default class DatabaseDriver implements QueueDriver {
    * Store job to database
    */
   public async store(path: string, payload: any, options?: StoreOptions) {
-    await this.database.table(this.config.tableName).insert({
-      class_path: path,
-      payload: SuperJSON.serialize(payload),
-      available_at: options?.availableAt || DateTime.now().toSQL({ includeOffset: false }),
-    })
+    const job = await this.database
+      .table(this.config.tableName)
+      .insert({
+        class_path: path,
+        payload: SuperJSON.serialize(payload),
+        available_at: options?.availableAt || DateTime.now().toSQL({ includeOffset: false }),
+      })
+      .returning('id')
+
+    return {
+      id: job[0].id,
+    }
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,7 +30,13 @@ export abstract class QueueDriver {
    * @param payload Additional job payload
    * @param options Additional driver specific options
    */
-  public abstract store(path: string, payload: any, options?: StoreOptions): Promise<void>
+  public abstract store(
+    path: string,
+    payload: any,
+    options?: StoreOptions
+  ): Promise<{
+    id: number | string
+  }>
 
   /**
    * Get next job from the queue


### PR DESCRIPTION
THis PR makes it so, that job ID is returned, when job is stored (dispatched)

```ts
let job = await TestJob.dispatch({ name: 'foo', email: 'foobar@example.com' })
console.log(job)
// { id: 7902 }
```

TODO:
- [x] Add docs about it

Fixes https://github.com/cavai-research/Adonis-Queue/issues/35