### PR TITLE
Commit routes

### DIFF
--- a/commands/StartQueue.ts
+++ b/commands/StartQueue.ts
@@ -17,6 +17,15 @@ export default class StartQueue extends BaseCommand {
   public static description = 'Run the queue'
 
   public async run() {
+    /**
+     * We need to commit routes, otherwise might get issues,
+     * since @adonisjs/drive tries to register it's routes at startup
+     * without commiting routes trying to use Drive inside job will might errors
+     * Especially when also using @adonisjs/attachment-lite
+     */
+    const router = this.application.container.resolveBinding('Adonis/Core/Route')
+    router.commit()
+
     await import(this.application.startPath('jobs'))
   }
 }


### PR DESCRIPTION
Since there's some deep dependency "features" we need to commit routes, to be able to use `@adonisjs/attachment-lite` and `@adonisjs/drive` inside jobs that are run in distributed separate processes. It's not an issue when using in-memory Queue driver. Since then main Adonis instance will have routes already commited by the API itself

It's a thing that gets resolved in Adonis V6 :)