### PR TITLE
Commit routes at before queue startup

### DIFF
--- a/commands/StartQueue.ts
+++ b/commands/StartQueue.ts
@@ -26,6 +26,15 @@ export default class StartQueue extends BaseCommand {
     const QueueManager = this.application.container.use('Cavai/Adonis-Queue')
     const Config = this.application.container.use('Adonis/Core/Config')
 
+    /**
+     * We need to commit routes, otherwise might get issues,
+     * since @adonisjs/drive tries to register it's routes at startup
+     * without commiting routes trying to use Drive inside job will might errors
+     * Especially when also using @adonisjs/attachment-lite
+     */
+    const router = this.application.container.resolveBinding('Adonis/Core/Route')
+    router.commit()
+
     await QueueManager.start(this.name || Config.get('queue.default'))
   }
 }


### PR DESCRIPTION
Since there's some deep dependency "features" we need to commit routes, to be able to use `@adonisjs/attachment-lite` and `@adonisjs/drive` inside jobs that are run in distributed separate processes. It's not an issue when using in-memory Queue driver. Since then main Adonis instance will have routes already commited by the API itself

It's a thing that gets resolved in Adonis V6 :)