### PR TITLE
Make things a bit quiter. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,19 @@ export default defineConfig({
       driver: 'never',
     },
   },
+  /**
+   * Optional config parameters
+   */
+
+  // Custom log level - defaults to app config logger.level
+  logLevel: 'debug',
+
+  // Log when no jobs in queue
+  logEmptyQueue: false,
+  
+  // Custom idenfier for logs entries
+  logChild: 'adonis-queue',
+  
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ import MailJob from 'App/Jobs/Mails/MailJob'
 import { DateTime } from 'luxon'
 
 // Dispatch job and delay it's execution for one day
-await MailJob.dispatch().delay(DateTime.now().plus({days: 1}))
+await MailJob.dispatch().delay(DateTime.now().plus({ days: 1 }))
 
 // You can also specify date as string
 // This job won't execute before given date
@@ -188,42 +188,42 @@ This driver needs to extend abstract `QueueDriver` to ensure everything works co
 // NeverQueueDriver.ts
 import { QueueDriver } from '@cavai/adonis-queue/build/src/types'
 
-export class NeverQueueDriver extends QueueDriver{
+export class NeverQueueDriver extends QueueDriver {
   /**
    * Do nothing, NeverQueue will never store any jobs
    */
-  public async store () {
-    console.log('Stored nothing');
+  public async store() {
+    console.log('Stored nothing')
   }
 
   /**
    * Just return null, since there is never going to be job to return
    */
-  public async getNext () {
+  public async getNext() {
     return null
   }
 
   /**
    * Always return null, since there are no jobs
    */
-  public async getJob () {
+  public async getJob() {
     return null
   }
 
   /**
    * Keeping on with never having jobs theme
    */
-  public async reSchedule () { }
+  public async reSchedule() {}
 
   /**
    * Do nothing
    */
-  public async markFailed () { }
+  public async markFailed() {}
 
   /**
    * Do nothing
    */
-  public async remove () {}
+  public async remove() {}
 }
 ```
 
@@ -240,11 +240,12 @@ import type { ApplicationContract } from '@ioc:Adonis/Core/Application'
 import { NeverQueueDriver } from './NeverQueueDriver'
 
 export default class NeverQueueProvider {
-  constructor (protected app: ApplicationContract) {}
+  constructor(protected app: ApplicationContract) {}
 
-  public register () {
+  public register() {
     // Register your own bindings
-    DriversCollection.extend('never', () => { // TS error, solution below
+    DriversCollection.extend('never', () => {
+      // TS error, solution below
       return new NeverQueueDriver()
     })
   }
@@ -252,6 +253,7 @@ export default class NeverQueueProvider {
 ```
 
 Even tho our new queue is working now and we can configure it to be used inside `config/queue.ts`, we are going to get some TypeScript errors, about `never` queue not acceptable queue
+
 > Argument of type '"never"' is not assignable to parameter of type '"database"'.ts(2345)
 
 To fix that, need to create TS typings file: `contracts/queue.ts`
@@ -264,8 +266,8 @@ import { NeverQueueDriver } from '@/providers/NeverQueue/NeverQueueDriver'
 
 declare module '@cavai/adonis-queue' {
   export interface QueueDriverList {
-    // Appending it to drivers list and naming it 
-    'never': () => NeverQueueDriver
+    // Appending it to drivers list and naming it
+    never: () => NeverQueueDriver
   }
 }
 ```
@@ -302,11 +304,11 @@ export default defineConfig({
   logLevel: 'debug',
 
   // Log when no jobs in queue
-  logEmptyQueue: false,
-  
+  logEmptyQueue: true,
+
   // Custom idenfier for logs entries
   logChild: 'adonis-queue',
-  
+
 })
 ```
 

--- a/src/DefineConfig.ts
+++ b/src/DefineConfig.ts
@@ -67,6 +67,7 @@ export function defineConfig<
   return {
     default: config.default,
     logLevel: config.logLevel,
+    quiet: config.quiet,
     queues: managerQueues,
   }
 }

--- a/src/DefineConfig.ts
+++ b/src/DefineConfig.ts
@@ -40,7 +40,13 @@ export function defineConfig<
       [K in keyof QueueDriverList]: { driver: K } & GetConfig<Parameters<QueueDriverList[K]>>
     }[keyof QueueDriverList]
   >
->(config: { default: keyof KnownQueues; queues: KnownQueues; logLevel?: string }) {
+>(config: {
+  default: keyof KnownQueues
+  queues: KnownQueues
+  logLevel?: string
+  logEmptyQueue?: boolean
+  logChild?: string
+}) {
   /**
    * Queues queues should always be provided
    */
@@ -70,8 +76,8 @@ export function defineConfig<
 
   return {
     default: config.default,
-    logLevel: config.logLevel,   
-    logEmptyQueue: config.logEmptyQueue,
+    logLevel: config.logLevel,
+    logEmptyQueue: config.logEmptyQueue || true,
     logChild: config.logChild,
     queues: managerQueues,
   }

--- a/src/DefineConfig.ts
+++ b/src/DefineConfig.ts
@@ -10,6 +10,8 @@ type GetConfig<T extends any[]> = T extends [] ? {} : T[0]
  * {
  *    default: 'somename',
  *    logLevel: 'info',
+ *    logEmptyQueue: false,
+ *    logChild: 'adonis-queue',
  *    queues: {
  *       somename: {
  *         driver: 'db',
@@ -22,6 +24,8 @@ type GetConfig<T extends any[]> = T extends [] ? {} : T[0]
  * {
  *    default: 'somename',
  *    logLevel: 'info',
+ *    logEmptyQueue: false,
+ *    logChild: 'adonis-queue',
  *    queues: {
  *       somename: () => new DatabaseDrive({
  *          table_name: 'sjdasjk',
@@ -66,8 +70,9 @@ export function defineConfig<
 
   return {
     default: config.default,
-    logLevel: config.logLevel,
-    quiet: config.quiet,
+    logLevel: config.logLevel,   
+    logEmptyQueue: config.logEmptyQueue,
+    logChild: config.logChild,
     queues: managerQueues,
   }
 }

--- a/src/QueueManager.ts
+++ b/src/QueueManager.ts
@@ -18,17 +18,23 @@ export class QueueManager<Mappings extends Record<string, QueueManagerFactory>> 
   protected driver: QueueDriver
 
   constructor(
-    protected config: { default: keyof Mappings; queues: Mappings; logLevel?: string; logEmptyQueue?: boolean; logChild?: string },
+    protected config: {
+      default: keyof Mappings
+      queues: Mappings
+      logLevel?: string
+      logEmptyQueue?: boolean
+      logChild?: string
+    },
     protected logger: LoggerContract,
     protected jobsRoot: string
   ) {
     // Setup default driver
     this.driver = this.use(config.default)
-    
+
     this.logger.level = config.logLevel || logger.level
-    
+
     if (config.logChild) {
-      this.logger.child({name: config.logChild})
+      this.logger.child({ name: config.logChild })
     }
   }
 
@@ -79,7 +85,7 @@ export class QueueManager<Mappings extends Record<string, QueueManagerFactory>> 
 
     // No job queued, continue with life
     if (!job) {
-      this.config.logEmptyQueue && this.logger.debug('No jobs in queue')
+      ;(this.config.logEmptyQueue ?? true) && this.logger.debug('No jobs in queue')
       return
     }
     this.logger.debug({ job }, 'Execution started')

--- a/src/QueueManager.ts
+++ b/src/QueueManager.ts
@@ -18,13 +18,18 @@ export class QueueManager<Mappings extends Record<string, QueueManagerFactory>> 
   protected driver: QueueDriver
 
   constructor(
-    protected config: { default: keyof Mappings; queues: Mappings; logLevel?: string },
+    protected config: { default: keyof Mappings; queues: Mappings; logLevel?: string; logEmptyQueue?: boolean; logChild?: string },
     protected logger: LoggerContract,
     protected jobsRoot: string
   ) {
     // Setup default driver
     this.driver = this.use(config.default)
+    
     this.logger.level = config.logLevel || logger.level
+    
+    if (config.logChild) {
+      this.logger.child({name: config.logChild})
+    }
   }
 
   public use<K extends keyof Mappings>(queue: K): QueueDriver {
@@ -74,7 +79,7 @@ export class QueueManager<Mappings extends Record<string, QueueManagerFactory>> 
 
     // No job queued, continue with life
     if (!job) {
-      this.logger.debug('No jobs in queue')
+      this.config.logEmptyQueue && this.logger.debug('No jobs in queue')
       return
     }
     this.logger.debug({ job }, 'Execution started')

--- a/tests/queueManager.spec.ts
+++ b/tests/queueManager.spec.ts
@@ -21,6 +21,7 @@ test.group('QueueManager', (group) => {
       {
         default: 'db',
         logLevel: 'debug',
+        logChild: 'adonis-queue',
         queues: {
           db: () => driver,
         },


### PR DESCRIPTION
Problem: QueueManager assigns this.logger.level on the shared app.logger, affecting app-wide logging and making logLevel in config/queue.ts fragile when other code changes the root level. Idle polling logs "No jobs in queue" at debug on every poll cycle, which bloats logs when pollingDelay is low and app log level is set to `debug`

Proposal: Use logger.child({ name: 'adonis-queue' }) instead of mutating the root logger. Optionally add logEmptyQueue: false or downgrade the idle message to be ignored so it won't bloat debug logs.

Example: 
<img width="583" height="755" alt="image" src="https://github.com/user-attachments/assets/0bba09a9-81e9-4849-bd7f-be2e7b5f6107" />
